### PR TITLE
resolve() and reject() should be bound to the Deferred instance

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -21,11 +21,11 @@ export class Deferred<T> {
     return this._promise;
   }
 
-  resolve(value?: T | PromiseLike<T>): void {
+  resolve = (value?: T | PromiseLike<T>): void => {
     this._resolve(value);
   }
 
-  reject(reason?: any): void {
+  reject = (reason?: any): void => {
     this._reject(reason);
   }
 

--- a/test/spec.ts
+++ b/test/spec.ts
@@ -40,6 +40,14 @@ describe('Deferred', () => {
       });
     });
 
+    it('should be bound to the Deferred instance', () => {
+      let resolve = deferred.resolve;
+      resolve('Chai Maxx');
+      return deferred.promise.then((value: string) => {
+        assert(value === 'Chai Maxx');
+      });
+    });
+
   });
 
   describe('.reject', () => {
@@ -54,6 +62,14 @@ describe('Deferred', () => {
 
     it('should reject the promise with the reason', () => {
       deferred.reject('CONTRADICTION');
+      return deferred.promise.catch((reason: string) => {
+        assert(reason === 'CONTRADICTION');
+      });
+    });
+
+    it('should be bound to the Deferred instance', () => {
+      let reject = deferred.reject;
+      reject('CONTRADICTION');
       return deferred.promise.catch((reason: string) => {
         assert(reason === 'CONTRADICTION');
       });


### PR DESCRIPTION
resolve() and reject() should be bound to the `Deferred` instance to make it possible to use them like this:

```
const deferred = new Deferred<string>();
const { resolve, reject } = deferred;
[...later on...]
resolve("foo");
```

Right now the above code terminates with an error because `this` will be `undefined` within the body of the `resolve()` function.