### PR TITLE
refactor: simplify further

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -5,28 +5,14 @@
  * http://opensource.org/licenses/mit-license.php
  */
 export class Deferred<T> {
-
-  private readonly _promise: Promise<T>
-  private _resolve: (value?: T | PromiseLike<T>) => void
-  private _reject: (reason?: any) => void
+  readonly promise: Promise<T>
+  readonly resolve: (value?: T | PromiseLike<T>) => void
+  readonly reject: (reason?: any) => void
 
   constructor () {
-    this._promise = new Promise<T>((resolve, reject) => {
-      this._resolve = resolve
-      this._reject = reject
-    })
+    this.promise = new Promise<T>((resolve, reject) => (
+      (this as any).resolve = resolve,
+      (this as any).reject = reject
+    ))
   }
-
-  get promise (): Promise<T> {
-    return this._promise
-  }
-
-  resolve = (value?: T | PromiseLike<T>): void => {
-    this._resolve(value)
-  }
-
-  reject = (reason?: any): void => {
-    this._reject(reason)
-  }
-
 }


### PR DESCRIPTION
Removing the private properties reduces the impact of `ts-deferred` on bundle size.